### PR TITLE
bit reversal is available since base-4.14

### DIFF
--- a/src/GHC/Word/Compat.hs
+++ b/src/GHC/Word/Compat.hs
@@ -18,7 +18,7 @@ module GHC.Word.Compat (Word8, pattern GHC.Word.Compat.W8#,
     byteSwap64,
 
     -- * Bit reversal
-#if MIN_VERSION_base(4,12,0)
+#if MIN_VERSION_base(4,14,0)
     bitReverse8,
     bitReverse16,
     bitReverse32,


### PR DESCRIPTION
This change fixes build failure with ghc-8.8.4 by changing
the condition for inclusion of bit reversal functions.

The base-4.16.0.0 documentation for the "bitReverse..."
functions in Data.Word and in GHC.Word says
"Since: base-4.12.0.0".  But versions of the base
documentation prior to base-4.14.0.0 do not mention
these functions.  Furthermore, these functions are
not defined by either the GHC 8.8.4 source code
or the GHC 8.6.5 source code.

Therefore it seems that the current base documentation
is in error, and the actual introduction of these
particular bit reversal functions was in base-4.14.

The documentation issue is now filed as:

  https://gitlab.haskell.org/ghc/ghc/-/issues/21260