### PR TITLE
Avoid warnings about non-exhaustive pattern matching.

### DIFF
--- a/src/GHC/Int/Compat.hs
+++ b/src/GHC/Int/Compat.hs
@@ -2,11 +2,20 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE CPP #-}
-module GHC.Int.Compat (Int8, pattern GHC.Int.Compat.I8#,
-    Int16, pattern GHC.Int.Compat.I16#,
-    Int32, pattern GHC.Int.Compat.I32#,
+module GHC.Int.Compat (Int8,
+    Int16,
+    Int32,
     Int64(..),
     Int(..),
+#if MIN_VERSION_ghc_prim(0,8,0)
+    pattern GHC.Int.Compat.I8#,
+    pattern GHC.Int.Compat.I16#,
+    pattern GHC.Int.Compat.I32#,
+#else
+    pattern W.I8#,
+    pattern W.I16#,
+    pattern W.I32#,
+#endif
 
     uncheckedIShiftL64#, uncheckedIShiftRA64#,
     -- * Equality operators
@@ -17,29 +26,22 @@ module GHC.Int.Compat (Int8, pattern GHC.Int.Compat.I8#,
     eqInt32, neInt32, gtInt32, geInt32, ltInt32, leInt32,
     eqInt64, neInt64, gtInt64, geInt64, ltInt64, leInt64) where
 
-import GHC.Prim
 import GHC.Int as W
 
-pattern I8# :: Int# -> Int8
 #if MIN_VERSION_ghc_prim(0,8,0)
+
+import GHC.Prim
+
+pattern I8# :: Int# -> Int8
 pattern I8# x <- (W.I8# (int8ToInt# -> x)) where
   I8# x = W.I8# (intToInt8# x)
-#else
-pattern I8# x = W.I8# x
-#endif
 
 pattern I16# :: Int# -> Int16
-#if MIN_VERSION_ghc_prim(0,8,0)
 pattern I16# x <- (W.I16# (int16ToInt# -> x)) where
   I16# x = W.I16# (intToInt16# x)
-#else
-pattern I16# x = W.I16# x
-#endif
 
 pattern I32# :: Int# -> Int32
-#if MIN_VERSION_ghc_prim(0,8,0)
 pattern I32# x <- (W.I32# (int32ToInt# -> x)) where
   I32# x = W.I32# (intToInt32# x)
-#else
-pattern I32# x = W.I32# x
+
 #endif

--- a/src/GHC/Word/Compat.hs
+++ b/src/GHC/Word/Compat.hs
@@ -2,12 +2,20 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE CPP #-}
-module GHC.Word.Compat (Word8, pattern GHC.Word.Compat.W8#,
-    Word16, pattern GHC.Word.Compat.W16#,
-    Word32, pattern GHC.Word.Compat.W32#,
+module GHC.Word.Compat (Word8,
+    Word16,
+    Word32,
     Word64(..),
     Word(..),
-    
+#if MIN_VERSION_ghc_prim(0,8,0)
+    pattern GHC.Word.Compat.W8#,
+    pattern GHC.Word.Compat.W16#,
+    pattern GHC.Word.Compat.W32#,
+#else
+    pattern W.W8#,
+    pattern W.W16#,
+    pattern W.W32#,
+#endif
         -- * Shifts
     uncheckedShiftL64#,
     uncheckedShiftRL64#,
@@ -33,29 +41,22 @@ module GHC.Word.Compat (Word8, pattern GHC.Word.Compat.W8#,
     eqWord32, neWord32, gtWord32, geWord32, ltWord32, leWord32,
     eqWord64, neWord64, gtWord64, geWord64, ltWord64, leWord64) where
 
-import GHC.Prim
 import GHC.Word as W
 
-pattern W8# :: Word# -> Word8
 #if MIN_VERSION_ghc_prim(0,8,0)
+
+import GHC.Prim
+
+pattern W8# :: Word# -> Word8
 pattern W8# x <- (W.W8# (word8ToWord# -> x)) where
   W8# x = W.W8# (wordToWord8# x)
-#else
-pattern W8# x = W.W8# x
-#endif
 
 pattern W16# :: Word# -> Word16
-#if MIN_VERSION_ghc_prim(0,8,0)
 pattern W16# x <- (W.W16# (word16ToWord# -> x)) where
   W16# x = W.W16# (wordToWord16# x)
-#else
-pattern W16# x = W.W16# x
-#endif
 
 pattern W32# :: Word# -> Word32
-#if MIN_VERSION_ghc_prim(0,8,0)
 pattern W32# x <- (W.W32# (word32ToWord# -> x)) where
   W32# x = W.W32# (wordToWord32# x)
-#else
-pattern W32# x = W.W32# x
+
 #endif


### PR DESCRIPTION
This change concerns only the "! MIN_VERSION_ghc_prim(0,8,0)" case, in which
this package is needed only for forward compatibility with the opposite case.

With GHC 8.8.4 and a pattern synonym such as "pattern W8# x = W.W8# x",
GHC considers the pattern (W8# _) to be non-exhaustive, unlike the actual
data constructor GHC.Word.W8#.

This change avoids that problem by reexporting GHC.Word.W8# instead of a new
pattern.  Naturally, it does the same for W16#, W32#, I8#, I16#, and I32#.