### PR TITLE
support GHC 9.4 (Word# -> Word64#)

### DIFF
--- a/src/GHC/Prim/Compat.hs
+++ b/src/GHC/Prim/Compat.hs
@@ -16,7 +16,11 @@ module GHC.Prim.Compat (
 import GHC.Prim (
     Addr#,ByteArray#,Int#,MutableByteArray#,State#,Word#,
     wordToWord8#,wordToWord16#,wordToWord32#,
-    word8ToWord#,word16ToWord#,word32ToWord#)
+    word8ToWord#,word16ToWord#,word32ToWord#
+#if MIN_VERSION_ghc_prim(0,9,0)
+    ,wordToWord64#,word64ToWord#
+#endif
+    )
 import qualified GHC.Prim as Prim
 #else
 import GHC.Prim (
@@ -31,6 +35,14 @@ import GHC.Prim (
 
 #if MIN_VERSION_ghc_prim(0,8,0)
 
+#if !MIN_VERSION_ghc_prim(0,9,0)
+wordToWord64#, word64ToWord# :: Word# -> Word#
+wordToWord64# w = w
+word64ToWord# w = w
+{-# INLINE wordToWord64# #-}
+{-# INLINE word64ToWord# #-}
+#endif
+
 indexWord8Array# :: ByteArray# -> Int# -> Word#
 indexWord8Array# arr i = word8ToWord# (Prim.indexWord8Array# arr i)
 {-# INLINE indexWord8Array# #-}
@@ -44,7 +56,7 @@ indexWord32Array# arr i = word32ToWord# (Prim.indexWord32Array# arr i)
 {-# INLINE indexWord32Array# #-}
 
 indexWord64Array# :: ByteArray# -> Int# -> Word#
-indexWord64Array# = Prim.indexWord64Array#
+indexWord64Array# arr i = word64ToWord# (Prim.indexWord64Array# arr i)
 {-# INLINE indexWord64Array# #-}
 
 readWord8Array# :: MutableByteArray# d -> Int# -> State# d -> (# State# d, Word# #)
@@ -66,7 +78,9 @@ readWord32Array# arr ix st =
 {-# INLINE readWord32Array# #-}
 
 readWord64Array# :: MutableByteArray# d -> Int# -> State# d -> (# State# d, Word# #)
-readWord64Array# = Prim.readWord64Array#
+readWord64Array# arr ix st =
+  let !(# st', v #) = Prim.readWord64Array# arr ix st
+   in (# st', word64ToWord# v #)
 {-# INLINE readWord64Array# #-}
 
 writeWord8Array# :: MutableByteArray# d -> Int# -> Word# -> State# d -> State# d
@@ -82,7 +96,7 @@ writeWord32Array# arr ix v st = Prim.writeWord32Array# arr ix (wordToWord32# v) 
 {-# INLINE writeWord32Array# #-}
 
 writeWord64Array# :: MutableByteArray# d -> Int# -> Word# -> State# d -> State# d
-writeWord64Array# = Prim.writeWord64Array#
+writeWord64Array# arr ix v st = Prim.writeWord64Array# arr ix (wordToWord64# v) st
 {-# INLINE writeWord64Array# #-}
 
 indexWord8OffAddr# :: Addr# -> Int# -> Word#
@@ -98,7 +112,7 @@ indexWord32OffAddr# addr off = word32ToWord# (Prim.indexWord32OffAddr# addr off)
 {-# INLINE indexWord32OffAddr# #-}
 
 indexWord64OffAddr# :: Addr# -> Int# -> Word#
-indexWord64OffAddr# addr off = Prim.indexWord64OffAddr# addr off
+indexWord64OffAddr# addr off = word64ToWord# (Prim.indexWord64OffAddr# addr off)
 {-# INLINE indexWord64OffAddr# #-}
 
 readWord8OffAddr# :: Addr# -> Int# -> State# d -> (# State# d, Word# #)
@@ -120,7 +134,9 @@ readWord32OffAddr# addr off st =
 {-# INLINE readWord32OffAddr# #-}
 
 readWord64OffAddr# :: Addr# -> Int# -> State# d -> (# State# d, Word# #)
-readWord64OffAddr# = Prim.readWord64OffAddr#
+readWord64OffAddr# addr off st =
+  let !(# st', v #) = Prim.readWord64OffAddr# addr off st
+   in (# st', word64ToWord# v #)
 {-# INLINE readWord64OffAddr# #-}
 
 writeWord8OffAddr# :: Addr# -> Int# -> Word# -> State# d -> State# d
@@ -139,7 +155,8 @@ writeWord32OffAddr# addr off v st =
 {-# INLINE writeWord32OffAddr# #-}
 
 writeWord64OffAddr# :: Addr# -> Int# -> Word# -> State# d -> State# d
-writeWord64OffAddr# = Prim.writeWord64OffAddr#
+writeWord64OffAddr# addr off v st =
+  Prim.writeWord64OffAddr# addr off (wordToWord64# v) st
 {-# INLINE writeWord64OffAddr# #-}
 
 #endif


### PR DESCRIPTION
GHC 9.4 switches `Word64` internal representation to `Word64#` from
`Word#`. Similar changes were made to various "Word64" primitives (which
actually worked on `Word#`. The fix is simply to apply the same wrapping
as is done for the other fixed-width primitive integers.

Addresses #3 